### PR TITLE
Added functionality to support Ring polymer initialization for PIMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ doc/latex/
 build/
 build7.5/
 build-7.5/
+build_temp/
 src/Makefile
 Makefile
 benchmark/*nvprof

--- a/python/Sim.cpp
+++ b/python/Sim.cpp
@@ -71,6 +71,9 @@ BOOST_PYTHON_MODULE(Sim) {
     export_FixLinearMomentum();
     export_FixRigid();
 
+    export_FixExternal();
+    export_FixExternalHarmonic();
+
     export_FixPair();
     export_FixLJCut(); //make there be a pair base class in boost!
     export_FixLJCutFS();

--- a/python/Sim.cpp
+++ b/python/Sim.cpp
@@ -73,6 +73,7 @@ BOOST_PYTHON_MODULE(Sim) {
 
     export_FixExternal();
     export_FixExternalHarmonic();
+    export_FixExternalQuartic();
 
     export_FixPair();
     export_FixLJCut(); //make there be a pair base class in boost!

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -35,8 +35,42 @@ std::string Atom::getType() {
     return handles->at(type);
 }
 
+void Atom::setBeadPos(int n, int nPerRingPoly, std::vector<Vector> &xsNM) {
+    float sqrt2           = sqrt(2.0);
+    float invP            = 1.0 / (float) nPerRingPoly;
+    float twoPiInvP       = 2.0f * M_PI * invP;
+    float invSqrtP        = sqrt(invP);
+    int halfP = nPerRingPoly/2;
 
+    // k = 0
+    Vector xn = xsNM[0];
+    
+    // k = halfP
+    // xn += xsNM[halfP]*(-1)**n
+    if ( n % 2 == 0) {
+      xn += xsNM[halfP];}
+    else {
+      xn -= xsNM[halfP];}
+    
+    // k = 1,...,P/2-1; n = 1,...,P
+    for (int k = 1; k < halfP; k++) {
+      float  cosval = cos(twoPiInvP * k * n); // cos(2*pi*k*n/P)
+      xn += xsNM[k] * sqrt2 * cosval;
+    }
+    
+    // k = P/2+1,...,P-1; n = 1,...,P
+    for (int k = halfP+1; k < nPerRingPoly; k++) {
+      float  sinval = sin(twoPiInvP * k * n); // cos(2*pi*k*n/P)
+      xn += xsNM[k] * sqrt2 * sinval;
+    }
+    
+    // replace evolved back-transformation
+    pos = xn*invSqrtP;
+}
 
+//void Atom::setBeadVel(int nPerRingPoly, float betaP) {
+//    Vector vn;
+//}
 
 void export_Atom () { 
     py::class_<Atom>("Atom", py::no_init)

--- a/src/Atom.h
+++ b/src/Atom.h
@@ -56,6 +56,11 @@ public:
 
     std::string getType();
 
+    void setBeadPos(int n, int nPerRingPoly, std::vector<Vector> &xsNM);
+    // displaces the position of a bead based on free ring-polymer distribution
+
+    //void setBeadVel(int nPerRingPoly, float betaP);
+
 
 };
 

--- a/src/Evaluators/ChargeEvaluatorDSF.h
+++ b/src/Evaluators/ChargeEvaluatorDSF.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef EVALUATOR_DSF_
-#define EVALUATOR_DSF
 
 #include "cutils_math.h"
 
@@ -9,19 +7,19 @@ class ChargeEvaluatorDSF {
         float alpha;
         float A;
         float shift;
+        float qqr_to_eng;
         inline __device__ float3 force(float3 dr, float lenSqr, float qi, float qj, float multiplier) {
             float r2inv = 1.0f/lenSqr;
             float rinv = sqrtf(r2inv);
             float len = sqrtf(lenSqr);
-            float forceScalar = qi*qj*(erfcf((alpha*len))*r2inv+A*expf(-alpha*alpha*lenSqr)*rinv-shift)*rinv * multiplier;
+            float forceScalar = qqr_to_eng * qi*qj*(erfcf((alpha*len))*r2inv+A*expf(-alpha*alpha*lenSqr)*rinv-shift)*rinv * multiplier;
             return dr * forceScalar;
         }
         inline __device__ float energy(float lenSqr, float qi, float qj, float multiplier) {
             printf("DSF engs not implemented\n");
             return 0;
         }
-        ChargeEvaluatorDSF(float alpha_, float A_, float shift_) : alpha(alpha_), A(A_), shift(shift_) {};
+        ChargeEvaluatorDSF(float alpha_, float A_, float shift_, float qqr_to_eng_) : alpha(alpha_), A(A_), shift(shift_), qqr_to_eng(qqr_to_eng_) {};
 
 };
 
-#endif

--- a/src/Evaluators/EvaluatorWrapper.h
+++ b/src/Evaluators/EvaluatorWrapper.h
@@ -29,7 +29,7 @@ public:
             } else {
                 compute_force_iso<PAIR_EVAL, COMP_PAIRS, N_PARAM, false, CHARGE_EVAL, COMP_CHARGES> <<<NBLOCK(nAtoms), PERBLOCK, N_PARAM*numTypes*numTypes*sizeof(float)>>>(nAtoms, xs, fs, neighborCounts, neighborlist, cumulSumMaxPerBlock, warpSize, parameters, numTypes, bounds, onetwoStr, onethreeStr, onefourStr, virials, qs, qCutoff*qCutoff, pairEval, chargeEval);
             }
-        }
+        } 
     }
     virtual void energy(int nAtoms, float4 *xs, float *perParticleEng, uint16_t *neighborCounts, uint *neighborlist, uint32_t *cumulSumMaxPerBlock, int warpSize, float *parameters, int numTypes, BoundsGPU bounds, float onetwoStr, float onethreeStr, float onefourStr, float *qs, float qCutoff) {
         if (COMP_PAIRS or COMP_CHARGES) {

--- a/src/Evaluators/ExternalEvaluate.h
+++ b/src/Evaluators/ExternalEvaluate.h
@@ -1,0 +1,42 @@
+#include "BoundsGPU.h"
+#include "cutils_func.h"
+#include "helpers.h"
+
+
+template <class EVALUATOR, bool COMPUTE_VIRIALS>
+__global__ void compute_force_external(int nAtoms,float4 *xs, float4 *fs, uint groupTag, EVALUATOR eval) 
+        {
+	int idx = GETIDX();
+	if (idx < nAtoms) {
+	  float4 forceWhole = fs[idx];
+	  uint groupTagAtom = * (uint *) &forceWhole.w;
+	  // Check if atom is part of group affected by external potential
+	  if (groupTagAtom & groupTag) {
+	    float4 posWhole = xs[idx];
+	    float3 pos      = make_float3(posWhole);
+            float3 force    = eval.force( pos );      // compute the force due to ext. potential!
+            float4 f        = fs[idx];
+            f               = f + force;
+            fs[idx]         = f;
+            }
+	  }
+	}
+
+
+template <class EVALUATOR>
+__global__ void compute_energy_external(int nAtoms,float4 *xs, float4 *fs, float *perParticleEng, uint groupTag, EVALUATOR eval) 
+        {
+	int idx = GETIDX();
+	if (idx < nAtoms) {
+	  float4 forceWhole = fs[idx];
+	  uint groupTagAtom = * (uint *) &forceWhole.w;
+	  // Check if atom is part of group affected by external potential
+	  if (groupTagAtom & groupTag) {
+	    float4 posWhole = xs[idx];
+	    float3 pos      = make_float3(posWhole);
+            float  uext     = eval.energy( pos );      // compute the energy due to ext. potential!
+            perParticleEng[idx] += uext;
+            }
+	  }
+	}
+

--- a/src/Evaluators/ExternalEvaluatorHarmonic.h
+++ b/src/Evaluators/ExternalEvaluatorHarmonic.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "cutils_math.h"
+
+class EvaluatorExternalHarmonic {
+	public:
+	float3 k;
+        float3 r0;
+
+        // default constructor
+        EvaluatorExternalHarmonic () {};
+        EvaluatorExternalHarmonic (float3 k_, float3 r0_ ) {
+            k = k_;
+            r0= r0_;
+        };
+       
+        // force function called by compute_force_external(...) in ExternalEvaluate.h
+	inline __device__ float3 force(float3 pos) {
+                float3 dr = pos - r0;
+        	return -k * dr;
+        };
+
+        // force function called by compute_energy_external(...) in ExternalEvaluate.h
+	inline __device__ float energy(float3 pos) {
+                float3 dr  = pos - r0;
+		float3 dr2 = dr * dr; 
+        	return 0.5*(k.x * dr2.x + k.y*dr2.y + k.z*dr2.z) ;
+        };
+
+};
+

--- a/src/Evaluators/ExternalEvaluatorQuartic.h
+++ b/src/Evaluators/ExternalEvaluatorQuartic.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "cutils_math.h"
+
+class EvaluatorExternalQuartic {
+	public:
+	float3 k1;
+	float3 k2;
+	float3 k3;
+	float3 k4;
+        float3 r0;
+
+        // default constructor
+        EvaluatorExternalQuartic () {};
+        EvaluatorExternalQuartic (float3 k1_, float3 k2_, float3 k3_, float3 k4_, float3 r0_ ) {
+            k1 = k1_;
+            k2 = k2_;
+            k3 = k3_;
+            k4 = k4_;
+            r0 = r0_;
+        };
+       
+        // force function called by compute_force_external(...) in ExternalEvaluate.h
+	inline __device__ float3 force(float3 pos) {
+                float3 dr  = pos - r0;
+		float3 dr2 = dr * dr;
+		float3 dr3 = dr2* dr; 
+        	return -k1 - 2*k2*dr -3*k3*dr2 - 4*k4*dr3;
+        };
+
+        // force function called by compute_energy_external(...) in ExternalEvaluate.h
+	inline __device__ float energy(float3 pos) {
+                float3 dr  = pos - r0;
+		float3 dr2 = dr * dr;
+		float3 dr3 = dr2* dr; 
+		float3 dr4 = dr2* dr2; 
+        	return dot(k1,dr) + dot(k2,dr2) + dot(k3,dr3) + dot(k4,dr4);
+        };
+
+};
+

--- a/src/Fixes/Fix.h
+++ b/src/Fixes/Fix.h
@@ -232,6 +232,8 @@ public:
 
     virtual void setEvalWrapper(){};
 
+    virtual void updateForPIMD(){};
+
     std::string evalWrapperMode;
     //self or offload
     void setEvalWrapperMode(std::string mode);
@@ -266,6 +268,7 @@ public:
 
     virtual Interpolator *getInterpolator(std::string);
 
+    virtual void updateForPIMD(int nPerRingPoly) {};
 
 };
 

--- a/src/Fixes/FixBond.h
+++ b/src/Fixes/FixBond.h
@@ -246,6 +246,22 @@ class FixBond : public Fix, public TypedItemHolder {
                 }
             }
         }
+
+        void updateForPIMD(int nPerRingPoly) {
+            std::vector<BondVariant> RPbonds(bonds.size()*nPerRingPoly);
+            for (int i=0; i<bonds.size(); i++) {
+                CPUMember  asType = boost::get<CPUMember>(bonds[i]);
+                for (int j=0; j<nPerRingPoly; j++) {
+                    CPUMember RPcopy = asType;                      // create copy of the forcer member
+                    RPcopy.ids[0] = asType.ids[0]*nPerRingPoly + j; // new id for RP atom1 in bond
+                    RPcopy.ids[1] = asType.ids[1]*nPerRingPoly + j; // new id for RP atom2 in bond
+                    RPbonds[i*nPerRingPoly+j] = RPcopy;             // place new member for RP bonds
+                }
+            }
+            bonds = RPbonds;    // update the forcers
+            pyListInterface.requestRefreshPyList();
+        }
+
 };
 
 #endif

--- a/src/Fixes/FixChargePairDSF.cu
+++ b/src/Fixes/FixChargePairDSF.cu
@@ -53,12 +53,13 @@ std::vector<float> FixChargePairDSF::getRCuts() {
 
 void FixChargePairDSF::compute(bool computeVirials) {
     int nAtoms = state->atoms.size();
+    int nPerRingPoly = state->nPerRingPoly;
     GPUData &gpd = state->gpd;
     GridGPU &grid = state->gridGPU;
     int activeIdx = gpd.activeIdx();
     uint16_t *neighborCounts = grid.perAtomArray.d_data.data();
     float *neighborCoefs = state->specialNeighborCoefs;
-    evalWrap->compute(nAtoms, gpd.xs(activeIdx), gpd.fs(activeIdx),
+    evalWrap->compute(nAtoms,nPerRingPoly, gpd.xs(activeIdx), gpd.fs(activeIdx),
                   neighborCounts, grid.neighborlist.data(), grid.perBlockArray.d_data.data(),
                   state->devManager.prop.warpSize, nullptr, 0, state->boundsGPU,
                   neighborCoefs[0], neighborCoefs[1], neighborCoefs[2], gpd.virials.d_data.data(), gpd.qs(activeIdx), r_cut, computeVirials);

--- a/src/Fixes/FixChargePairDSF.h
+++ b/src/Fixes/FixChargePairDSF.h
@@ -28,9 +28,9 @@ public:
 
     void setParameters(float alpha_, float r_cut_);
     void compute(bool);
-    ChargeEvaluatorDSF generateEvaluator() {
-        return ChargeEvaluatorDSF(alpha, A, shift);
-    }
+    ChargeEvaluatorDSF generateEvaluator();
+    void setEvalWrapper();
+    std::vector<float> getRCuts();
 
 };
 

--- a/src/Fixes/FixExternal.cpp
+++ b/src/Fixes/FixExternal.cpp
@@ -1,0 +1,13 @@
+#include "FixExternal.h"
+#include "State.h"
+
+namespace py = boost::python;
+
+// export FixExternal()
+void export_FixExternal() {
+	py::class_<FixExternal, SHARED(FixExternal), py::bases<Fix> > (
+		"FixExternal",
+		py::no_init
+	);
+}
+

--- a/src/Fixes/FixExternal.h
+++ b/src/Fixes/FixExternal.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifndef FIX_EXTERNAL_H
+#define FIX_EXTERNAL_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "GPUArrayGlobal.h"
+#include "Fix.h"
+
+class State;
+
+void export_FixExternal();
+
+class FixExternal: public Fix {
+
+public:
+        // General variables for the class
+
+	// constructor
+	FixExternal(SHARED(State) state_, std::string handle_, 
+			std::string groupHandle_, std::string type_, 
+			bool forceSingle_, bool requiresCharges_, int applyEvery_)
+		: Fix(state_, handle_, groupHandle_, type_, true, false, false, applyEvery_)
+		{
+		
+       		 };
+};
+
+#endif

--- a/src/Fixes/FixExternalHarmonic.cu
+++ b/src/Fixes/FixExternalHarmonic.cu
@@ -1,0 +1,66 @@
+#include "FixExternalHarmonic.h"
+
+#include "BoundsGPU.h"
+#include "GridGPU.h"
+#include "State.h"
+#include "boost_for_export.h"
+#include "cutils_math.h"
+#include "ExternalEvaluate.h"
+
+const std::string ExternalHarmonicType = "ExternalHarmonic";
+using namespace std;
+namespace py = boost::python;
+
+// the constructor for FixExternalHarmonic
+FixExternalHarmonic::FixExternalHarmonic(SHARED(State) state_, std::string handle_, std::string groupHandle_,
+                                 Vector k_, Vector r0_)
+  : FixExternal(state_, handle_, groupHandle_, ExternalHarmonicType, true,  false, 1 ),
+    k(k_.asFloat3()), r0(r0_.asFloat3()) { };
+
+// compute function
+void FixExternalHarmonic::compute(bool computeVirials) {
+	GPUData &gpd  = state->gpd;
+	int activeIdx = gpd.activeIdx();
+	int n         = state->atoms.size();
+	if (computeVirials) {
+		compute_force_external<EvaluatorExternalHarmonic, true> <<<NBLOCK(n), PERBLOCK>>>(n,  gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), groupTag, evaluator);
+	} else {
+		compute_force_external<EvaluatorExternalHarmonic, false> <<<NBLOCK(n), PERBLOCK>>>(n, gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), groupTag, evaluator);
+	}
+};
+
+void FixExternalHarmonic::singlePointEng(float *perParticleEng) {
+        GPUData &gpd  = state->gpd;
+        int activeIdx = gpd.activeIdx();
+        int n         = state->atoms.size();
+        compute_energy_external<EvaluatorExternalHarmonic> <<<NBLOCK(n), PERBLOCK>>>(n,  gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), perParticleEng, groupTag, evaluator);
+};
+
+
+bool FixExternalHarmonic::prepareForRun() {
+    // set this fix's evaulator with the appropriate parameters
+    evaluator = EvaluatorExternalHarmonic(k, r0);
+    return true;
+};
+
+bool FixExternalHarmonic::postRun () {
+    return true;
+};
+
+// export function
+void export_FixExternalHarmonic() {
+	py::class_<FixExternalHarmonic, SHARED(FixExternalHarmonic), py::bases<FixExternal>, boost::noncopyable > (
+		"FixExternalHarmonic",
+		py::init<SHARED(State), string, string, Vector, Vector> (
+			py::args("state", "handle", "groupHandle", "k", "r0")
+		)
+	)
+	.def_readwrite("k", &FixExternalHarmonic::k)
+	.def_readwrite("r0", &FixExternalHarmonic::r0)
+	;
+}
+
+

--- a/src/Fixes/FixExternalHarmonic.h
+++ b/src/Fixes/FixExternalHarmonic.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "FixExternal.h"
+#include "ExternalEvaluatorHarmonic.h"
+
+
+
+void export_FixExternalHarmonic();
+
+class FixExternalHarmonic : public FixExternal {
+	public:
+		FixExternalHarmonic(SHARED(State), std::string handle_, std::string groupHandle_,
+							Vector k_, Vector r0_);
+	float3 k;    // component-wise coefficent from harmonic potential
+	float3 r0;   // origin for harmonic potential
+		
+        void compute(bool);
+
+	bool prepareForRun();
+		
+        bool postRun();
+
+        void singlePointEng(float *);
+
+	EvaluatorExternalHarmonic evaluator; // evaluator for harmonic wall interactions
+
+};
+
+
+
+

--- a/src/Fixes/FixExternalQuartic.cu
+++ b/src/Fixes/FixExternalQuartic.cu
@@ -1,0 +1,70 @@
+#include "FixExternalQuartic.h"
+
+#include "BoundsGPU.h"
+#include "GridGPU.h"
+#include "State.h"
+#include "boost_for_export.h"
+#include "cutils_math.h"
+#include "ExternalEvaluate.h"
+
+const std::string ExternalQuarticType = "ExternalQuartic";
+using namespace std;
+namespace py = boost::python;
+
+// the constructor for FixExternalQuartic
+FixExternalQuartic::FixExternalQuartic(SHARED(State) state_, std::string handle_, std::string groupHandle_,
+                                 Vector k1_, Vector k2_, Vector k3_, Vector k4_ , Vector r0_)
+  : FixExternal(state_, handle_, groupHandle_, ExternalQuarticType, true,  false, 1 ),
+    k1(k1_.asFloat3()), k2(k2_.asFloat3()), k3(k3_.asFloat3()), k4(k4_.asFloat3()),
+    r0(r0_.asFloat3()) { };
+
+// compute function
+void FixExternalQuartic::compute(bool computeVirials) {
+	GPUData &gpd  = state->gpd;
+	int activeIdx = gpd.activeIdx();
+	int n         = state->atoms.size();
+	if (computeVirials) {
+		compute_force_external<EvaluatorExternalQuartic, true> <<<NBLOCK(n), PERBLOCK>>>(n,  gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), groupTag, evaluator);
+	} else {
+		compute_force_external<EvaluatorExternalQuartic, false> <<<NBLOCK(n), PERBLOCK>>>(n, gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), groupTag, evaluator);
+	}
+};
+
+void FixExternalQuartic::singlePointEng(float *perParticleEng) {
+        GPUData &gpd  = state->gpd;
+        int activeIdx = gpd.activeIdx();
+        int n         = state->atoms.size();
+        compute_energy_external<EvaluatorExternalQuartic> <<<NBLOCK(n), PERBLOCK>>>(n,  gpd.xs(activeIdx),
+                    gpd.fs(activeIdx), perParticleEng, groupTag, evaluator);
+};
+
+
+bool FixExternalQuartic::prepareForRun() {
+    // set this fix's evaulator with the appropriate parameters
+    evaluator = EvaluatorExternalQuartic(k1,k2,k3,k4,r0);
+    return true;
+};
+
+bool FixExternalQuartic::postRun () {
+    return true;
+};
+
+// export function
+void export_FixExternalQuartic() {
+	py::class_<FixExternalQuartic, SHARED(FixExternalQuartic), py::bases<FixExternal>, boost::noncopyable > (
+		"FixExternalQuartic",
+		py::init<SHARED(State), string, string, Vector, Vector, Vector, Vector, Vector> (
+			py::args("state", "handle", "groupHandle", "k1","k2","k3","k4", "r0")
+		)
+	)
+	.def_readwrite("k1", &FixExternalQuartic::k1)
+	.def_readwrite("k2", &FixExternalQuartic::k2)
+	.def_readwrite("k3", &FixExternalQuartic::k3)
+	.def_readwrite("k4", &FixExternalQuartic::k4)
+	.def_readwrite("r0", &FixExternalQuartic::r0)
+	;
+}
+
+

--- a/src/Fixes/FixExternalQuartic.h
+++ b/src/Fixes/FixExternalQuartic.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "FixExternal.h"
+#include "ExternalEvaluatorQuartic.h"
+
+
+
+void export_FixExternalQuartic();
+
+class FixExternalQuartic : public FixExternal {
+	public:
+		FixExternalQuartic(SHARED(State), std::string handle_, std::string groupHandle_,
+							Vector k1_, Vector k2_, Vector k3_, Vector k4, Vector r0_);
+	float3 k1;    // component-wise coefficent from linear potential
+	float3 k2;    // component-wise coefficent from harmonic potential
+	float3 k3;    // component-wise coefficent from cubic potential
+	float3 k4;    // component-wise coefficent from quartic potential
+	float3 r0;    // origin for potential
+		
+        void compute(bool);
+
+	bool prepareForRun();
+		
+        bool postRun();
+
+        void singlePointEng(float *);
+
+	EvaluatorExternalQuartic evaluator; // evaluator for harmonic wall interactions
+
+};
+
+
+
+

--- a/src/Fixes/FixLinearMomentum.cu
+++ b/src/Fixes/FixLinearMomentum.cu
@@ -18,10 +18,11 @@ __global__ void rescale_all(int nAtoms, float4 *vs, float4 *sumData, float3 dims
     if (idx < nAtoms) {
         float4 v = vs[idx];
         float4 sum = sumData[0];
-        int invMassTotal = 1.0f / v.w;
+        float invMassTotal = 1.0f / sum.w;
         v.x -= sum.x * invMassTotal * dims.x;
         v.y -= sum.y * invMassTotal * dims.y;
         v.z -= sum.z * invMassTotal * dims.z;
+        vs[idx] = v;
     }
 }
 
@@ -33,10 +34,11 @@ __global__ void rescale_group(int nAtoms, float4 *vs, float4 *fs, uint32_t group
         if (tag & groupTag) {
             float4 v = vs[idx];
             float4 sum = sumData[0];
-            int invMassTotal = 1.0f / sum.w;
+            float invMassTotal = 1.0f / sum.w;
             v.x -= sum.x * invMassTotal * dims.x;
             v.y -= sum.y * invMassTotal * dims.y;
             v.z -= sum.z * invMassTotal * dims.z;
+            vs[idx] = v;
         }
     }
 }
@@ -48,6 +50,7 @@ void FixLinearMomentum::compute(bool computeVirials) {
     float4 *fs = state->gpd.vs.getDevData();
     int warpSize = state->devManager.prop.warpSize;
 
+    sumMomentum.memset(0); 
     if (groupHandle == "all") {
         accumulate_gpu<float4, float4, SumVectorXYZOverW, N_DATA_PER_THREAD> <<<NBLOCK(nAtoms / (double) N_DATA_PER_THREAD), PERBLOCK, N_DATA_PER_THREAD*PERBLOCK*sizeof(float4)>>>
             (

--- a/src/Fixes/FixPotentialMultiAtom.h
+++ b/src/Fixes/FixPotentialMultiAtom.h
@@ -83,6 +83,23 @@ class FixPotentialMultiAtom : public Fix, public TypedItemHolder {
             forcerTypes[n] = holder;
         }
 
+    void updateForPIMD(int nPerRingPoly) {
+        std::vector<CPUVariant> RPforcers(forcers.size()*nPerRingPoly);
+        for (int i=0; i<forcers.size(); i++) {
+            CPUVariant v      = forcers[i];
+            CPUMember  asType = boost::get<CPUMember>(v);
+            for (int j=0; j<nPerRingPoly; j++) {
+                CPUMember RPcopy = asType;                          // create copy of the forcer member
+                for (int k=0; k<N ; k++) {
+                    RPcopy.ids[k] = asType.ids[k]*nPerRingPoly + j; // new id for RPatom
+                }
+                RPforcers[i*nPerRingPoly+j] = RPcopy;   // place new member for RP interactions
+            }
+        }
+        forcers = RPforcers;    // update the forcers
+        pyListInterface.requestRefreshPyList();
+    }
+
 	std::string restartChunk(std::string format) {
 	  std::stringstream ss;
 	  ss << "<types>\n";

--- a/src/Integrators/IntegratorVerlet.cu
+++ b/src/Integrators/IntegratorVerlet.cu
@@ -447,7 +447,7 @@ void IntegratorVerlet::nve_x() {
 	  }
 	}
 	int   nPerRingPoly = state->nPerRingPoly;
-        int   nRingPoly = state->atoms.size() / nPerRingPoly;
+    int   nRingPoly = state->atoms.size() / nPerRingPoly;
 	float omegaP    = (float) nPerRingPoly / state->units.hbar * state->units.boltz * temp;
     	nve_xPIMD_cu<<<NBLOCK(nRingPoly), PERBLOCK, sizeof(float3) * 2 *PERBLOCK * nPerRingPoly>>>(
 	        nRingPoly,

--- a/src/ReadConfig.cpp
+++ b/src/ReadConfig.cpp
@@ -137,29 +137,25 @@ void loadGroupInfo(pugi::xml_node &config, State *state) {
         cout << "Failed to load groups from file " << endl;
     }
 }
-/*
-vector<Bond> buildBonds(pugi::xml_node &config, State *state, string tag, int numBonds) {
-	vector<Bond> bonds;
-	auto bonds_xml = config.child("bond");
-	if (bonds_xml) {
-		istringstream ss(bonds_xml.first_child().value());
-		string line;
-		while (ss >> line) {
-			Atom *atoms[2];
-			atoms[0] = state->atomFromId(atoi(line.c_str()));
-			ss >> line;
-			atoms[1] = state->atomFromId(atoi(line.c_str()));
-			ss >> line;
-			double k = atof(line.c_str());
-			ss >> line;
-			double rEq = atof(line.c_str());
-			assert(atoms[0] != (Atom *) NULL and atoms[1] != (Atom *) NULL);
-			state->addBond(atoms[0], atoms[1], k, rEq);
-		}
-	}
-	return bonds;
+
+
+void loadMolecules(pugi::xml_node &config, State *state) {
+    auto mol_xml = config.child("molecules").first_child();
+    if (mol_xml) {
+        while (mol_xml) {
+            std::istringstream ss(mol_xml.first_child().value());
+            std::string s;
+            vector<int> ids;
+            while (ss >> s) {
+                ids.push_back(atoi(s.c_str()));
+            }
+            state->createMolecule(ids);
+            mol_xml = mol_xml.next_sibling();
+        }
+        
+    }
 }
-*/
+
 pugi::xml_node ReadConfig::readFix(string type, string handle) {
     if (config) {
         auto node = config->child("fixes").first_child();
@@ -256,6 +252,7 @@ bool ReadConfig::read() {
 	for (Atom &a : readAtoms) {
 		state->addAtomDirect(a);
 	}
+    loadMolecules(*config, state);
 	return true;
 
 }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -737,6 +737,7 @@ void State::deleteAtoms() {
     idBuffer.erase(idBuffer.begin(), idBuffer.end());
     maxIdExisting = -1;
     idToIdx.erase(idToIdx.begin(), idToIdx.end());
+    molecules = py::list();
 }
 
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -791,6 +791,115 @@ Vector generateVector(State &s, py::list valsPy) {
 }
 
 
+bool State::preparePIMD() {
+    if (nPerRingPoly > 1) {
+        int nAtoms = atoms.size();          // this is current number of atoms in system
+        int nTot   = nAtoms * nPerRingPoly; // this is the total number of beads for PIMD
+        std::vector<Atom> RPatoms;          // new vector of atoms to replace current atoms
+        RPatoms.reserve(nTot);              
+        boost::python::list RPmolecules;    // new list of molecules to replace current list
+
+        // Extract temperature and spring frequency
+        double temp=1.0;
+        for (Fix *f: fixes) {
+          if ( f->isThermostat && f->groupHandle == "all" ) {
+            std::string t = "temp";
+            temp = f->getInterpolator(t)->getCurrentVal();
+          }
+        }
+        float betaP     = 1.0f / units.boltz / temp;
+        float omegaP    = (float) nPerRingPoly / units.hbar / betaP;
+        float invP            = 1.0 / (float) nPerRingPoly;
+        float twoPiInvP       = 2.0f * M_PI * invP;
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // UPDATE ATOMS
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        for (int i=0; i < nAtoms; i++) {
+            Atom   ai = atoms[i];
+            int baseId = ai.id;
+            baseId    *= nPerRingPoly;      // stride the existing id's by nPerRingPoly
+
+            // prepare for position initialization
+            // here we are sampling a set of normal-mode coordinates
+            // from the free ring-polymer solution
+            // those coordinates will then be used in a back transformation to obtain
+            // a new set of coordinates with centroid at the initial position of the atoms
+            std::vector<Vector> xsNM;       // vector for containing normal-mode coordinates
+            xsNM.reserve(nPerRingPoly);
+            for (int k = 0; k < nPerRingPoly; k++) {
+                float omegak = 2.0f * omegaP * sinf( k * twoPiInvP * 0.5);
+                float sigmak = powf((float) nPerRingPoly  / betaP / ai.mass,0.5) / omegak; // sigma = sqrt(1/ beta_P * m *omegak^2)
+                std::normal_distribution<float> distNM(0.0,sigmak);
+                float xk, yk, zk;
+                xk = distNM(randomNumberGenerator);
+                yk = distNM(randomNumberGenerator);
+                zk = distNM(randomNumberGenerator);
+                xsNM.push_back(Vector(xk,yk,zk));
+            }
+
+            // prepare for velocity initialization
+            std::normal_distribution<float> distVel(0.0,sqrtf(ai.mass / betaP));
+
+            // fill in atom copies
+            for (int k=0; k < nPerRingPoly; k++) {
+                int RPid = baseId + k;          // get new ID based on position in ring polymer
+                Atom aik = ai;                  // atom copy
+                aik.id = RPid;                  // update id
+                aik.setBeadPos(k+1,nPerRingPoly,xsNM);  // adjust position
+                // resample velocity
+                Vector vk;
+                vk[0] = distVel(randomNumberGenerator); // vx
+                vk[1] = distVel(randomNumberGenerator); // vy
+                vk[2] = distVel(randomNumberGenerator); // vz
+                aik.setVel(vk);                // adjust velocity
+                RPatoms.push_back(aik);        // add atom to list
+            }
+
+        }
+        // replace atoms with the new RPatoms list
+        atoms = RPatoms;
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // UPDATE MOLECULES
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        int nMol = py::len(molecules);
+        py::list molecsRP;
+        // go over each molecule
+        for (int i=0; i<nMol; i++) {
+            py::extract<Molecule *> molecEx(molecules[i]);
+            Molecule *moli = molecEx;
+            std::vector<int> moliIds;   // vector for containing ids defining molecule
+            // extract the ids for the molecule
+            for (int id : moli->ids) {
+                moliIds.push_back(id);
+            }
+            // iterate over beads/time slices and systematically increase IDs by timeslice
+            int nAtmPerMol = moliIds.size();
+            for (int k = 0; k < nPerRingPoly; k++) {
+                std::vector<int> molikIds = moliIds;        // new ids for the molecule at kth timeslice
+                for (int l = 0; l < nAtmPerMol; l++) {
+                    molikIds[l] = moliIds[l]*nPerRingPoly +k;   // stride by nPerRingPoly and increase to time slice
+                }
+                molecsRP.append(Molecule(this,molikIds));       // add molecule
+            }
+        }
+        // replace the list of molecules with the new list of molecsRP
+        molecules = molecsRP;
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // UPDATE FIXES
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        for (Fix *fix : fixes) {
+            fix->updateForPIMD(nPerRingPoly);
+        }
+
+        return true;
+    }
+    else {
+        return false;
+    }
+}
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(State_seedRNG_overloads,State::seedRNG,0,1)
 

--- a/src/State.h
+++ b/src/State.h
@@ -513,6 +513,16 @@ public:
 
     Units units;
 
+    bool preparePIMD();
+    //! Extends current simulation state to a path-integral representation
+    /*!
+     * \return True always
+     *
+     * This function makes nPerRingPoly copies of the exiting atoms in the simulation
+     * and their interactions for use in path-integral molecular dynamics simultions
+     * currently, the same number of replicas are applied to all particles in the system.
+     */
+
 private:
     std::mt19937 randomNumberGenerator; //!< Random number generator
     bool rng_is_seeded; //!< True if seedRNG has been called

--- a/src/WriteConfig.cpp
+++ b/src/WriteConfig.cpp
@@ -69,6 +69,26 @@ void outputGroups(ofstream &outFile, State *state) {
     outFile << "</groupBits>\n";
     outFile << "</groupInfo>\n";
 }
+
+void outputMolecules(ofstream &outFile, State *state) {
+    outFile << "<molecules>\n";
+    int len = py::len(state->molecules);
+    for (int i=0; i<len; i++) {
+        outFile << "<m>\n";
+        py::extract<Molecule> mPy(state->molecules[i]);
+        if (!mPy.check()) {
+            assert(mPy.check());
+        }
+        Molecule m = mPy;
+        for (int id : m.ids) {
+            outFile << id << " ";
+        }
+        outFile << "</m>\n";
+    }
+    outFile << "</molecules>\n";
+
+}
+
 void writeXMLfileBase64(State *state, string fnFinal, int64_t turn, bool oneFilePerWrite, uint groupBit) {
     vector<Atom> &atoms = state->atoms;
     ofstream outFile;
@@ -131,6 +151,7 @@ void writeXMLfileBase64(State *state, string fnFinal, int64_t turn, bool oneFile
             );
 
     outputGroups(outFile, state);
+    outputMolecules(outFile, state);
     sprintf(buffer, "</configuration>\n");
     outFile << buffer;
     if (oneFilePerWrite) {
@@ -259,6 +280,7 @@ void writeXMLfile(State *state, string fnFinal, int64_t turn, bool oneFilePerWri
             }
             );
     outputGroups(outFile, state);
+    outputMolecules(outFile, state);
     sprintf(buffer, "</configuration>\n");
     outFile << buffer;
     if (oneFilePerWrite) {

--- a/src/includeFixes.h
+++ b/src/includeFixes.h
@@ -27,5 +27,6 @@
 #include "FixPressureBerendsen.h"
 #include "FixLinearMomentum.h"
 #include "FixRigid.h"
+#include "FixExternalHarmonic.h"
 
 #endif

--- a/src/includeFixes.h
+++ b/src/includeFixes.h
@@ -28,5 +28,6 @@
 #include "FixLinearMomentum.h"
 #include "FixRigid.h"
 #include "FixExternalHarmonic.h"
+#include "FixExternalQuartic.h"
 
 #endif

--- a/util_py/LAMMPS_Reader.py
+++ b/util_py/LAMMPS_Reader.py
@@ -1,4 +1,5 @@
 import re
+import os
 import sys
 import math
 DEGREES_TO_RADIANS = math.pi / 180.
@@ -25,6 +26,10 @@ class LAMMPS_Reader:
         self.LMPTypeToSimTypeImproper = {}
 
     def read(self, dataFn='', inputFns=[]):
+        if dataFn != '':
+            assert(os.path.isfile(dataFn))
+        for fn in inputFns:
+            assert(os.path.isfile(fn))
         self.dataFile = open(dataFn, 'r')
         self.inputFiles = [open(inputFn, 'r') for inputFn in inputFns]
         self.allFiles = [self.dataFile ] + self.inputFiles


### PR DESCRIPTION
* member function  'preparePIMD' was added to State to map existing
atoms, molecules, bonds, and multi-atom potentials in state to RP
representation.
* member function added to Atom to generate Cartesian coordinate positions from ring polymer normal modes. This is used for initialization of positions consistent with centroid at classical position assumed in State
* virtual member function added to Fix called updateForPIMD, which takes existing forcers and replicates them for new atoms needed in ring polymers. Functions that do things of this kind added to FixBond and FixPotentialMultiAtom